### PR TITLE
cdif --linebyline option

### DIFF
--- a/script/cdif
+++ b/script/cdif
@@ -947,6 +947,7 @@ Options:
 	--prefix-pattern    prefix pattern
 	--visible char=?    set visible attributes
 	--[no]lenience      suppress unexpected input warning (default true)
+	--lxl               compare input data line-by-line
 
 
 =head1 DESCRIPTION
@@ -1317,7 +1318,25 @@ by default.
 =item B<--linebyline>, B<--lxl>
 
 Compare input data line-by-line.  Consider the inputs as pairs of two
-lines each, and output the result of comparing them.
+lines each, and output the result of comparing each two lines.
+
+Suppose you have a document with old and new text on lines beginning
+with L<OLD:> and L<NEW:> labels.
+
+    OLD: this is old text
+    NEW: and this is updated document
+
+Only this old/new part can be compared using B<greple>'s B<-Mtee>
+module as follows.
+
+    greple -Mtee cdif --lxl -- --cm=N -GE '^OLD: (.*\n)^NEW: (.*\n)'
+
+B<-Mtee> module sends matched parts to the filter command and replace
+them by its result.  Consult L<App::Greple::tee> for detail.
+
+You can use L<teip(1)> command as well.
+
+    teip -g '^(OLD|NEW): -- cdif --lxl
 
 =back
 
@@ -1365,6 +1384,8 @@ L<App::sdif>, L<https://github.com/kaz-utashiro/sdif-tools>
 L<sdif(1)>, L<watchdiff(1)>
 
 L<Getopt::EX::Colormap>
+
+L<App::Greple::tee>
 
 L<https://taku910.github.io/mecab/>
 

--- a/script/cdif
+++ b/script/cdif
@@ -106,6 +106,7 @@ use Getopt::EX::Hashed; {
     has prefix_pattern => '    =s  ' , default => $prefix_default ;
     has visible        => '    =s@ ' , default => [] ;
     has lenience       => '    !   ' , default => 1 ;
+    has linebyline     => '    :2  ' , alias => 'lxl';
 
     has ignore_case         => 'i' ;
     has ignore_space_change => 'b' ;
@@ -338,7 +339,17 @@ while (<DIFF>) {
     #
     # normal diff
     #
-    if (($left, $cmd, $right) = /^([\d,]+)([adc])([\d,]+)\r?$/) {
+    if ($app->linebyline) {
+	my $old = $_;
+	my $new = <DIFF> // do {
+	    print $old;
+	    next;
+	};
+	compare(\$old, \$new) if $app->unit;
+	print color("OTEXT", $old);
+	print color("NTEXT", $new);
+    }
+    elsif (($left, $cmd, $right) = /^([\d,]+)([adc])([\d,]+)\r?$/) {
 	my $command_line = $_;
 	my($old, $del, $new);
 	eval {
@@ -1302,6 +1313,11 @@ number which ignores insert/delete newlines.
 
 Suppress warning message for unexpected input from diff command.  True
 by default.
+
+=item B<--linebyline>, B<--lxl>
+
+Compare input data line-by-line.  Consider the inputs as pairs of two
+lines each, and output the result of comparing them.
 
 =back
 


### PR DESCRIPTION
Introduce `--linebyline` or `--lxl` option to `cdif` command.

This is intended to use `cdif` as a simple filter command which compares consecutive two lines.